### PR TITLE
[vsphere] Intermediate foldes in VMware DC/Cluster tree

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_clusters.rb
+++ b/lib/fog/vsphere/requests/compute/list_clusters.rb
@@ -41,7 +41,7 @@ module Fog
 
         def cluster_path(cluster, datacenter_name)
           datacenter = find_raw_datacenter(datacenter_name)
-          cluster.pretty_path.gsub(/(#{datacenter.name}|#{datacenter.hostFolder.name})\//,'')
+          cluster.pretty_path.gsub(/(#{datacenter_name}|#{datacenter.hostFolder.name})\//,'')
         end
       end
 


### PR DESCRIPTION
Create VM failed when there was a folder between Datacenter and Clusters. This bug seemed to be a typo only.
